### PR TITLE
pwasm_abi::EndpointInterface support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,5 @@ rust:
   - nightly
 
 script:
-  - cargo build --features=pwasm-ethereum/std --verbose --all --release
-  - cargo test --features=pwasm-ethereum/std --verbose --all
+  - cargo build --verbose --all --release
+  - cargo test --verbose --all

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,10 @@ authors = ["NikVolf <nikvolf@gmail.com>", "Alexey Frolov <frol.rage@gmail.com>"]
 version = "0.3"
 features = ["std"]
 
+[dependencies.pwasm-ethereum ]
+git = "https://github.com/nikvolf/pwasm-ethereum"
+features = ["std"]
+
 [dependencies]
-pwasm-ethereum = { git = "https://github.com/nikvolf/pwasm-ethereum" }
 pwasm-abi = { git = "https://github.com/paritytech/pwasm-abi" }
 bigint = "4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,11 @@ name = "pwasm-test"
 version = "0.1.0"
 authors = ["NikVolf <nikvolf@gmail.com>", "Alexey Frolov <frol.rage@gmail.com>"]
 
+[dependencies.pwasm-std]
+version = "0.3"
+features = ["std"]
+
 [dependencies]
-pwasm-std = "0.3"
 pwasm-ethereum = { git = "https://github.com/nikvolf/pwasm-ethereum" }
+pwasm-abi = { git = "https://github.com/paritytech/pwasm-abi" }
 bigint = "4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,13 @@
 extern crate pwasm_std;
 extern crate pwasm_ethereum;
 extern crate bigint;
+extern crate pwasm_abi;
 
 mod external;
 mod externs;
 mod builder;
 
-pub use external::{External, ExternalInstance, Error};
+pub use external::{Endpoint, External, ExternalInstance, Error};
 pub use builder::{ExternalBuilder};
 pub use externs::*;
 

--- a/tests/calls.rs
+++ b/tests/calls.rs
@@ -6,7 +6,7 @@ extern crate pwasm_ethereum;
 use pwasm_std::hash::Address;
 use pwasm_ethereum as eth;
 
-use pwasm_test::{ExternalBuilder, ExternalInstance, get_external};
+use pwasm_test::{ExternalBuilder, ExternalInstance, get_external, Endpoint};
 
 /// An example of how to use get_external to access "calls" to some contract
 test_with_external!(
@@ -30,10 +30,10 @@ test_with_external!(
 
 test_with_external!(
 	ExternalBuilder::new().endpoint(
-		"0x16a0772b17ae004e6645e0e95bf50ad69498a34e".into(), Box::new(|_val, _input, result| {
+		"0x16a0772b17ae004e6645e0e95bf50ad69498a34e".into(), Endpoint::new(Box::new(|_val, _input, result| {
 			result[0] = 2;
 			Ok(())
-		})
+		}))
 	).build(),
 	has_called_with_endpoint {
 		let mut result = [0u8; 1];


### PR DESCRIPTION
Added conversion from `pwasm_abi::EndpointInterface` to pwasm_test::Endpoint to make it easy to build mock.

```rust
    use self::pwasm_token_contract::{TokenContract, Endpoint as TokenEndpoint};
    #[derive(Default)]
    struct TokenMock {
        balanceOf: U256,
        totalSupply: U256,
        transfer: bool,
        transferFrom: bool,
    }

    impl TokenMock {
        fn with_transfer(mut self, transfer: bool) -> TokenMock {
            self.transfer = transfer;
            self
        }
        fn with_transfer_from(mut self, transfer_from: bool) -> TokenMock {
            self.transferFrom = transfer_from;
            self
        }
    }

    impl TokenContract for TokenMock {
        fn constructor(&mut self, _total_supply: U256) {
        }
        fn balanceOf(&mut self, _owner: Address) -> U256 {
            self.balanceOf
        }
        fn totalSupply(&mut self) -> U256 {
            self.totalSupply
        }
        fn transfer(&mut self, _to: Address, _amount: U256) -> bool {
            self.transfer
        }
        fn approve(&mut self, _spender: Address, _value: U256) -> bool {
            self.approve
        }
        fn allowance(&mut self, _owner: Address, _spender: Address) -> U256 {
            self.allowance
        }
        fn transferFrom(&mut self, _from: Address, _to: Address, _amount: U256) -> bool {
            self.transferFrom
        }
    }

   let ext = ExternalBuilder::new()
   .endpoint("0x16a0772b17ae004e6645e0e95bf50ad69498a34e".into(), 
       TokenEndpoint::new(TokenMock::default().with_transfer_from(true)).into())
```

