### PR TITLE
Convenient API for external state manipulation added

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,21 @@ pub use external::{External, ExternalInstance, Error};
 pub use builder::{ExternalBuilder};
 pub use externs::*;
 
+pub fn ext_update<F>(updater: F) where F: Fn(ExternalBuilder) -> ExternalBuilder {
+	let builder = ExternalBuilder::from(get_external::<ExternalInstance>());
+	let ext = updater(builder).build();
+	set_external(Box::new(ext));
+}
+
+pub fn ext_reset<F>(updater: F) where F: Fn(ExternalBuilder) -> ExternalBuilder {
+	let ext = updater(ExternalBuilder::new()).build();
+	set_external(Box::new(ext));
+}
+
+pub fn ext_get() -> ExternalInstance {
+	get_external::<ExternalInstance>()
+}
+
 /// Test with provided externals manager (`impl ::pwasm_test::External`)
 #[macro_export]
 macro_rules! test_with_external {


### PR DESCRIPTION
For example:

```rust
    #[test]
    #[should_panic]
    fn should_panic_if_contract_cant_transfer_security_token() {
        ext_reset(|e| e
            .sender(BORROWER_ADDR)
            .timestamp(5)
            .endpoint(LOAN_TOKEN_ADDR, TokenEndpoint::new(TokenMock::default().with_transfer_from(true)).into())
            .endpoint(SECURITY_TOKEN_ADDR, TokenEndpoint::new(TokenMock::default().with_transfer_from(false)).into())
        );

        let mut contract = default_contract();
        assert_eq!(contract.accept(), false);
        // Set sender to lender
        ext_update(|e| e.sender(LENDER_ADDR));
        // Should panic because contact can't transfer amount of LOAN_TOKEN for some reason
        contract.accept();
    }
```